### PR TITLE
added feature: printing paths

### DIFF
--- a/bash_integration/bash_completion/jump
+++ b/bash_integration/bash_completion/jump
@@ -26,7 +26,7 @@ _jump()
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   opts="--help -h --add -a --del -d --list -l"
 
-  if [[ ${prev} == "-d" || ${prev} == "--del" ]] ; then
+  if [[ ${prev} == "-d" || ${prev} == "--del" || ${prev} == "-p" || ${prev} == "--path" ]] ; then
     # complete the del command with a list of the available bookmarks
     local bookmarks=$(jump --complete)
     COMPREPLY=( $(compgen -W "${bookmarks}" -- ${cur}) )

--- a/bin/jump-bin
+++ b/bin/jump-bin
@@ -43,6 +43,10 @@ begin
       options[:list] = true
     end
 
+    opts.on("-p", "--path", "Prints the path of the bookmark") do |v|
+      options[:path] = v
+    end
+
     opts.on("--bash-integration", "Prints the path to directory containing the Bash integration files") do
       puts "#{File.dirname(THIS_FILE)}/../bash_integration"
       exit

--- a/zsh_integration/jump
+++ b/zsh_integration/jump
@@ -29,7 +29,7 @@ _jump()
     prev="${user_input[$#user_input-1]}"
   fi
 
-  if [[ ${prev} = "-d" || ${prev} = "--del" ]] ; then
+  if [[ ${prev} = "-p" || ${prev} = "--path" || ${prev} = "-d" || ${prev} = "--del" ]] ; then
     # complete the del command with a list of the available bookmarks
     reply=( $(jump-bin --complete) )
     return 0
@@ -47,11 +47,13 @@ _jump()
 function jump {
   local args dest
   args=$*
-  #echo "jump called with |$args|"
   if [[ $#args -lt 1 ]]; then
     jump-bin --help
   elif [[ ${args[0,1]} = "-" ]]; then
+  # Case when --list is passed in
     jump-bin $*
+  elif [[ ${args[0,2]} = "-p" || ${args[0,6]} = "--path" ]]; then
+    dest="$(jump-bin $*)"
   else
     dest="$(jump-bin $*)" && cd "$dest"
   fi


### PR DESCRIPTION
Added a command to print (or echo) a path of a bookmark. (If you look at the source code, what this does is circumvent a call to `cd` in `zsh_integration/jump`.)

This is a very simple change to the source code; however it makes the tool more powerful. For example, the following shell commands now work:
```
cp `jp -p bookmark1/file1.cpp` .
mv `jp -p bookmark2/file2.cpp` `jp -p bookmark1`
ls `jp -p bookmark2` | xargs rm
```
In other words, it provides a way to manipulate files in bookmarked directories without having to `cd`.

This feature has not been integrated to bash shells yet.