### PR TITLE
License section correction.

### DIFF
--- a/bin/jump-bin
+++ b/bin/jump-bin
@@ -16,7 +16,7 @@
 # GNU General Public License for more details.
 # 
 # You should have received a copy of the GNU General Public License
-# along with Keep; if not, write to the
+# along with jump; if not, write to the
 # Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 


### PR DESCRIPTION
Minor issue in the license section, referencing 'Keep' rather than 'jump'.